### PR TITLE
Update resource imports after project rename

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/screens/EmptyScreenContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/screens/EmptyScreenContent.kt
@@ -5,8 +5,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import kmp_app_template.composeapp.generated.resources.Res
-import kmp_app_template.composeapp.generated.resources.no_data_available
+import addon.composeapp.generated.resources.Res
+import addon.composeapp.generated.resources.no_data_available
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
 

--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/screens/detail/DetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/screens/detail/DetailScreen.kt
@@ -37,16 +37,16 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.jetbrains.kmpapp.data.MuseumObject
 import com.jetbrains.kmpapp.screens.EmptyScreenContent
-import kmp_app_template.composeapp.generated.resources.Res
-import kmp_app_template.composeapp.generated.resources.back
-import kmp_app_template.composeapp.generated.resources.label_artist
-import kmp_app_template.composeapp.generated.resources.label_credits
-import kmp_app_template.composeapp.generated.resources.label_date
-import kmp_app_template.composeapp.generated.resources.label_department
-import kmp_app_template.composeapp.generated.resources.label_dimensions
-import kmp_app_template.composeapp.generated.resources.label_medium
-import kmp_app_template.composeapp.generated.resources.label_repository
-import kmp_app_template.composeapp.generated.resources.label_title
+import addon.composeapp.generated.resources.Res
+import addon.composeapp.generated.resources.back
+import addon.composeapp.generated.resources.label_artist
+import addon.composeapp.generated.resources.label_credits
+import addon.composeapp.generated.resources.label_date
+import addon.composeapp.generated.resources.label_department
+import addon.composeapp.generated.resources.label_dimensions
+import addon.composeapp.generated.resources.label_medium
+import addon.composeapp.generated.resources.label_repository
+import addon.composeapp.generated.resources.label_title
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 


### PR DESCRIPTION
## Summary
- switch resource imports to `addon.composeapp.generated.resources`

## Testing
- `./gradlew build` *(fails: SDK location not found)*
- `./gradlew composeApp:compileKotlinMetadata`


------
https://chatgpt.com/codex/tasks/task_e_688e3b7f86608322bbc087015df73636