### PR TITLE
Rename Android app to Addon App

### DIFF
--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">KMP App</string>
+    <string name="app_name">Addon App</string>
 </resources>


### PR DESCRIPTION
## Summary
- rename the Android app display name to "Addon App"

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e3b7ca6408322a2fcd0c59964e61c