### PR TITLE
Set iOS framework base name to AddonApp

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
         iosSimulatorArm64()
     ).forEach { iosTarget ->
         iosTarget.binaries.framework {
-            baseName = "ComposeApp"
+            baseName = "AddonApp"
             isStatic = true
         }
     }


### PR DESCRIPTION
## Summary
- Set iOS framework's baseName to `AddonApp`

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e3b7bbdc48322ab640ae05eca4ba9