### PR TITLE
Rename package to com.akrafts.addon

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -62,11 +62,11 @@ kotlin {
 }
 
 android {
-    namespace = "com.jetbrains.kmpapp"
+    namespace = "com.akrafts.addon"
     compileSdk = 35
 
     defaultConfig {
-        applicationId = "com.jetbrains.kmpapp"
+        applicationId = "com.akrafts.addon"
         minSdk = 24
         targetSdk = 35
         versionCode = 1

--- a/composeApp/src/androidMain/kotlin/com/akrafts/addon/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/akrafts/addon/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.jetbrains.kmpapp
+package com.akrafts.addon
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity

--- a/composeApp/src/androidMain/kotlin/com/akrafts/addon/MuseumApp.kt
+++ b/composeApp/src/androidMain/kotlin/com/akrafts/addon/MuseumApp.kt
@@ -1,7 +1,7 @@
-package com.jetbrains.kmpapp
+package com.akrafts.addon
 
 import android.app.Application
-import com.jetbrains.kmpapp.di.initKoin
+import com.akrafts.addon.di.initKoin
 
 class MuseumApp : Application() {
     override fun onCreate() {

--- a/composeApp/src/commonMain/kotlin/com/akrafts/addon/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/akrafts/addon/App.kt
@@ -1,4 +1,4 @@
-package com.jetbrains.kmpapp
+package com.akrafts.addon
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -11,8 +11,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
-import com.jetbrains.kmpapp.screens.detail.DetailScreen
-import com.jetbrains.kmpapp.screens.list.ListScreen
+import com.akrafts.addon.screens.detail.DetailScreen
+import com.akrafts.addon.screens.list.ListScreen
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/composeApp/src/commonMain/kotlin/com/akrafts/addon/data/MuseumApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/akrafts/addon/data/MuseumApi.kt
@@ -1,4 +1,4 @@
-package com.jetbrains.kmpapp.data
+package com.akrafts.addon.data
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body

--- a/composeApp/src/commonMain/kotlin/com/akrafts/addon/data/MuseumObject.kt
+++ b/composeApp/src/commonMain/kotlin/com/akrafts/addon/data/MuseumObject.kt
@@ -1,4 +1,4 @@
-package com.jetbrains.kmpapp.data
+package com.akrafts.addon.data
 
 import kotlinx.serialization.Serializable
 

--- a/composeApp/src/commonMain/kotlin/com/akrafts/addon/data/MuseumRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/akrafts/addon/data/MuseumRepository.kt
@@ -1,4 +1,4 @@
-package com.jetbrains.kmpapp.data
+package com.akrafts.addon.data
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob

--- a/composeApp/src/commonMain/kotlin/com/akrafts/addon/data/MuseumStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/akrafts/addon/data/MuseumStorage.kt
@@ -1,4 +1,4 @@
-package com.jetbrains.kmpapp.data
+package com.akrafts.addon.data
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/composeApp/src/commonMain/kotlin/com/akrafts/addon/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/com/akrafts/addon/di/Koin.kt
@@ -1,12 +1,12 @@
-package com.jetbrains.kmpapp.di
+package com.akrafts.addon.di
 
-import com.jetbrains.kmpapp.data.InMemoryMuseumStorage
-import com.jetbrains.kmpapp.data.KtorMuseumApi
-import com.jetbrains.kmpapp.data.MuseumApi
-import com.jetbrains.kmpapp.data.MuseumRepository
-import com.jetbrains.kmpapp.data.MuseumStorage
-import com.jetbrains.kmpapp.screens.detail.DetailViewModel
-import com.jetbrains.kmpapp.screens.list.ListViewModel
+import com.akrafts.addon.data.InMemoryMuseumStorage
+import com.akrafts.addon.data.KtorMuseumApi
+import com.akrafts.addon.data.MuseumApi
+import com.akrafts.addon.data.MuseumRepository
+import com.akrafts.addon.data.MuseumStorage
+import com.akrafts.addon.screens.detail.DetailViewModel
+import com.akrafts.addon.screens.list.ListViewModel
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.ContentType

--- a/composeApp/src/commonMain/kotlin/com/akrafts/addon/screens/EmptyScreenContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/akrafts/addon/screens/EmptyScreenContent.kt
@@ -1,4 +1,4 @@
-package com.jetbrains.kmpapp.screens
+package com.akrafts.addon.screens
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.Text

--- a/composeApp/src/commonMain/kotlin/com/akrafts/addon/screens/detail/DetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/akrafts/addon/screens/detail/DetailScreen.kt
@@ -1,4 +1,4 @@
-package com.jetbrains.kmpapp.screens.detail
+package com.akrafts.addon.screens.detail
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.background
@@ -35,8 +35,8 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
-import com.jetbrains.kmpapp.data.MuseumObject
-import com.jetbrains.kmpapp.screens.EmptyScreenContent
+import com.akrafts.addon.data.MuseumObject
+import com.akrafts.addon.screens.EmptyScreenContent
 import kmp_app_template.composeapp.generated.resources.Res
 import kmp_app_template.composeapp.generated.resources.back
 import kmp_app_template.composeapp.generated.resources.label_artist

--- a/composeApp/src/commonMain/kotlin/com/akrafts/addon/screens/detail/DetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/akrafts/addon/screens/detail/DetailViewModel.kt
@@ -1,8 +1,8 @@
-package com.jetbrains.kmpapp.screens.detail
+package com.akrafts.addon.screens.detail
 
 import androidx.lifecycle.ViewModel
-import com.jetbrains.kmpapp.data.MuseumObject
-import com.jetbrains.kmpapp.data.MuseumRepository
+import com.akrafts.addon.data.MuseumObject
+import com.akrafts.addon.data.MuseumRepository
 import kotlinx.coroutines.flow.Flow
 
 class DetailViewModel(private val museumRepository: MuseumRepository) : ViewModel() {

--- a/composeApp/src/commonMain/kotlin/com/akrafts/addon/screens/list/ListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/akrafts/addon/screens/list/ListScreen.kt
@@ -1,4 +1,4 @@
-package com.jetbrains.kmpapp.screens.list
+package com.akrafts.addon.screens.list
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.background
@@ -26,8 +26,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
-import com.jetbrains.kmpapp.data.MuseumObject
-import com.jetbrains.kmpapp.screens.EmptyScreenContent
+import com.akrafts.addon.data.MuseumObject
+import com.akrafts.addon.screens.EmptyScreenContent
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/akrafts/addon/screens/list/ListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/akrafts/addon/screens/list/ListViewModel.kt
@@ -1,9 +1,9 @@
-package com.jetbrains.kmpapp.screens.list
+package com.akrafts.addon.screens.list
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.jetbrains.kmpapp.data.MuseumObject
-import com.jetbrains.kmpapp.data.MuseumRepository
+import com.akrafts.addon.data.MuseumObject
+import com.akrafts.addon.data.MuseumRepository
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn

--- a/composeApp/src/iosMain/kotlin/com/akrafts/addon/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/akrafts/addon/MainViewController.kt
@@ -1,4 +1,4 @@
-package com.jetbrains.kmpapp
+package com.akrafts.addon
 
 import androidx.compose.ui.window.ComposeUIViewController
 

--- a/iosApp/Configuration/Config.xcconfig
+++ b/iosApp/Configuration/Config.xcconfig
@@ -1,3 +1,3 @@
 TEAM_ID=
-BUNDLE_ID=com.jetbrains.kmpapp.KMP-App-Template
+BUNDLE_ID=com.akrafts.addon.KMP-App-Template
 APP_NAME=KMP App


### PR DESCRIPTION
## Summary
- rename Kotlin sources from `com.jetbrains.kmpapp` to `com.akrafts.addon`
- update imports, Gradle namespace, and iOS bundle identifier

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e3b7deb108322b4f43e8261cb11c8